### PR TITLE
Revert "Fix the L"

### DIFF
--- a/index.md
+++ b/index.md
@@ -59,7 +59,7 @@ use gtk::signal::Inhibit;
 
 fn main() {
     gtk::init().unwrap_or_else(|_| panic!("Failed to initialize GTK."));
-    let window = gtk::Window::new(gtk::WindowType::TopLevel).unwrap();
+    let window = gtk::Window::new(gtk::WindowType::Toplevel).unwrap();
     window.set_title("First GTK+ Program");
     window.set_default_size(350, 70);
 


### PR DESCRIPTION
The spelling that matches the latest crates fits the original example now.