### PR TITLE
Enumerate all requirements for OS X

### DIFF
--- a/docs-src/requirements.md
+++ b/docs-src/requirements.md
@@ -24,7 +24,7 @@ The __gtk__ crate expects __GTK+__, __GLib__ and __Cairo__ development files to 
 ## OS X
 
 ~~~bash
-> brew install gtk+3
+> brew install gtk+3 atk cairo gdk-pixbuf pango
 ~~~
 
 ## Windows


### PR DESCRIPTION
For a project I'm building I want to use GTK on Mac. I include `glib`, `gdk`, and `gtk` directly and it wasn't enough to `brew install gtk+3`, I needed these additional packages. I'm not certain if this is the right place to document all of the requirements for everything under the `gtk-rs` umbrella.

Note that I'm still not able to build my packages correctly on my mac, as it complains about needing gdk >= 3.14, which it can't find, and I don't see a dedicated `gdk` package. If someone can help me out there I can add that to the requirements in this PR as well.