### PR TITLE
Add usage latest version

### DIFF
--- a/docs-src/index.md
+++ b/docs-src/index.md
@@ -19,12 +19,13 @@ layout: default
 By default the `gtk` crate provides only GTK+ 3.4 APIs. You can access more
 modern APIs by selecting one of the following features: `v3_6`, `v3_8`,
 `v3_10`, `v3_12`, `v3_14`, `v3_16`.
+{% assign gtk = site.data.crates | where: "name", "gtk" %}
 
 `Cargo.toml` example:
 
 ~~~toml
 [dependencies.gtk]
-version = "0.1.0"
+version = "{{ gtk[0].max_version }}"
 features = ["v3_16"]
 ~~~
 

--- a/index.md
+++ b/index.md
@@ -84,6 +84,20 @@ fn main() {
 }
 ~~~
 
+## Using latest, not published version
+
+Include `gtk` in your `Cargo.toml` and add `replace` ([see more about it](http://doc.crates.io/specifying-dependencies.html#overriding-dependencies)):
+{% assign gtk = site.data.crates | where: "name", "gtk" %}
+
+~~~toml
+[dependencies.gtk]
+version = "{{ gtk[0].max_version }}"
+features = ["v3_10"]
+
+[replace]
+"gtk:{{ gtk[0].max_version }}" = { git = 'https://github.com/gtk-rs/gtk' }
+~~~
+
 ## Projects using gtk
 * [Garta](https://github.com/zaari/garta)
 * [Gattii](https://gitlab.com/susurrus/gattii)


### PR DESCRIPTION
Found minor problem: code markdown for toml don't support sub-arrays (see temporary version in https://epashkin.github.io/)

In github this example looks fine:

## Using latest, not published version

Include `gtk` in your `Cargo.toml` and add `replace` ([see more about it](http://doc.crates.io/specifying-dependencies.html#overriding-dependencies)):

~~~toml
[dependencies.gtk]
version = "0.1.2"
features = ["v3_10"]

[replace]
"gtk:0.1.2" = { git = 'https://github.com/gtk-rs/gtk' }
~~~
