### PR TITLE
Added Way Cooler org to projects list

### DIFF
--- a/index.md
+++ b/index.md
@@ -107,5 +107,6 @@ features = ["v3_10"]
 * [tv-renamer](https://github.com/mmstick/tv-renamer)
 * [PNMixer-rs](https://github.com/hasufell/pnmixer-rust)
 * [BrewStillery](https://github.com/MonkeyLog/BrewStillery)
+* [Way Cooler](https://github.com/way-cooler)
 
 If you want yours to be added to this list, please create a [Pull Request](https://github.com/gtk-rs/gtk-rs.github.io/compare?expand=1) for it!


### PR DESCRIPTION
Added Way Cooler, which primarily uses the Cairo and Pango bindings (and probably the other bindings in the future).

I added the org itself, since the extensions also use cairo / pango.