### PR TITLE
Add System76's Popsicle App

### DIFF
--- a/index.md
+++ b/index.md
@@ -113,5 +113,6 @@ features = ["v3_10"]
 * [Fractal](https://gitlab.gnome.org/danigm/fractal)
 * [Epicwar Downloader](https://github.com/ab0v3g4me/epicwar-downloader)
 * [Whatschanging](https://github.com/mothsART/whatschanging)
+* [Popsicle](https://github.com/pop-os/popsicle/)
 
 If you want yours to be added to this list, please create a [Pull Request](https://github.com/gtk-rs/gtk-rs.github.io/compare?expand=1) for it!


### PR DESCRIPTION
System76 has created a multiple USB file flashing application in Rust with gtk-rs for the GTK frontend in the gtk workspace, and it is included by default in their Pop!_OS 18.04 image within the Utilities app category (simply named USB Flasher). The cli and gtk front ends are used internally for flashing large numbers of flash drives in parallel. Only USB devices are selectable, to prevent internal drives from being overwritten.

It's still a work in progress (mostly minor details to address), but should be complete before the 18.04 release. It is written as a dialog-driven application, with a header bar that lacks window controls. The first view allows asynchronously loading ISOs into memory and generating hashes from the in-memory copy of the ISO. The second view scans and lists USB devices that can be flashed to. The third view displays flash progress with multiple progress bars and labels to display the write rate. The final view will either display a success status, or list errors that were generated from devices that failed to flash. An extra view is also displayed when a critical error happens in the application, be that a failed mutex lock or an issue detecting and handling USB devices. Screenshots to follow shortly on the project page.

More Rust-based GTK applications are likely to be developed in Rust in the near future. -- author of the GTK front end :P