### PR TITLE
Enforce https on gtk-rs.org

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,4 +8,5 @@
 
     <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
+    <script>if (window.location.protocol !== "https:"){window.location.protocol = "https:";}</script>
 </head>


### PR DESCRIPTION
What do you think of it @sdroege and @EPashkin? Not very useful in itself but not we have a very "nice" **unsafe** in red in the url bar on chrome. So I assume it'd be better to enforce https to avoid it.