### PR TITLE
Website organization

### DIFF
--- a/docs-src/index.md
+++ b/docs-src/index.md
@@ -3,9 +3,9 @@ layout: default
 ---
 # Gtk-rs documentation
 
-### [Requirements](requirements.html)
+## [Requirements](requirements.html)
 
-### Crate API docs
+## Crate API docs
 
  - [**atk**](../docs/atk/)
  - [**cairo**](../docs/cairo/)
@@ -18,7 +18,9 @@ layout: default
  - [**pangocairo**](../docs/pangocairo/)
  - [**sourceview**](../docs/sourceview/)
 
-### Versions
+## [The GTK+ Project documentation](http://www.gtk.org/documentation.php)
+
+## Versions
 
 By default the `gtk` crate provides only GTK+ 3.14 APIs. You can access more
 modern APIs by selecting one of the following features: `v3_16`, `v3_18`, `v3_20`, `v3_22`, `v3_24`, `v3_26`, `v3_28`, `v3_30`.
@@ -35,8 +37,8 @@ features = ["v3_16"]
 not have easy access to the latest ones.** The higher the version, the fewer
 users will have it installed.
 
-### Examples
+## Tutorials and examples
 
-See the [examples repository](https://github.com/gtk-rs/examples).
-
-### [The GTK+ Project documentation](http://www.gtk.org/documentation.php)
+ * [Tutorials](/docs-src/tutorial).
+ * [Examples repository](https://github.com/gtk-rs/examples).
+ * [Projects using `gtk-rs`](/#projects-using-gtk-rs).

--- a/docs-src/tutorial/closures.md
+++ b/docs-src/tutorial/closures.md
@@ -150,7 +150,7 @@ button.connect_clicked(clone!(windows => move |_| {
 ```
 
 <div class="footer">
-<div><a href="/tuto/version">Specifying version</a>.</div>
+<div><a href="./version">Specifying version</a>.</div>
 <div><a href="/docs-src/tutorial">Going back to summary</a>.</div>
-<div><a href="/tuto/upcast_downcast">Upcast and downcast</a>.</div>
+<div><a href="./upcast_downcast">Upcast and downcast</a>.</div>
 </div>

--- a/docs-src/tutorial/cross.md
+++ b/docs-src/tutorial/cross.md
@@ -157,7 +157,7 @@ then download the windows 10 them from http://b00merang.weebly.com/windows-10.ht
     mv Windows-10-master /wherever/release/share/themes/Windows10
 
 <div class="footer">
-<div><a href="/tuto/glade">Glade</a>.</div>
+<div><a href="./glade">Glade</a>.</div>
 <div><a href="/docs-src/tutorial">Going back to summary</a>.</div>
 <div></div>
 </div>

--- a/docs-src/tutorial/glade.md
+++ b/docs-src/tutorial/glade.md
@@ -133,8 +133,8 @@ gtk::main();
 ```
 
 <div class="footer">
-<div><a href="/tuto/upcast_downcast">Upcast and downcast</a>.</div>
+<div><a href="./upcast_downcast">Upcast and downcast</a>.</div>
 <div><a href="/docs-src/tutorial">Going back to summary</a>.</div>
-<div><a href="/tuto/cross">Cross compiling from linux to windows</a>.</div>
+<div><a href="./cross">Cross compiling from linux to windows</a>.</div>
 <div></div>
 </div>

--- a/docs-src/tutorial/gnome_and_rust.md
+++ b/docs-src/tutorial/gnome_and_rust.md
@@ -62,7 +62,7 @@ The same goes for interfaces. The [gnome documentation](https://developer.gnome.
 I think that with this, you'll be able to write anything you want without too much difficulties. Now it's time to go deeper into `Gtk-rs` usage!
 
 <div class="footer">
-<div><a href="/tuto/rust_and_gtk">Rust and <code>Gtk-rs</code></a>.</div>
+<div><a href="./rust_and_gtk">Rust and <code>Gtk-rs</code></a>.</div>
 <div><a href="/docs-src/tutorial">Going back to summary</a>.</div>
-<div><a href="/tuto/version">Specifying version</a>.</div>
+<div><a href="./version">Specifying version</a>.</div>
 </div>

--- a/docs-src/tutorial/index.md
+++ b/docs-src/tutorial/index.md
@@ -4,23 +4,16 @@ layout: default
 
 # Tutorial
 
-Here's an introduction to `Gtk-rs` crates. For the users who already know Rust and Gtk, just skip the two first parts.
+## Introduction
 
-## Rust and `Gtk-rs`
+Here's an introduction to `Gtk-rs` crates. For the users who already know Rust and Gtk, just skip this part.
 
-This part explains how to add dependencies on the `Gtk-rs` crates, depending on your needs.
-
-[Read it here](./rust_and_gtk).
-
-## Gnome libraries and Rust
-
-This part explains a bit how the bindings of the Gnome libraries work in Rust.
-
-[Read it here](./gnome_and_rust).
+ * [Rust and `Gtk-rs`](./rust_and_gtk): This part explains how to add dependencies on the `Gtk-rs` crates, depending on your needs.
+ * [Gnome libraries and Rust](./gnome_and_rust): This part explains a bit how the bindings of the Gnome libraries work in Rust.
 
 ## Full usage of `Gtk-rs` crates
 
-In this part we'll go deeper into the mechanisms of the `Gtk-rs` crates. If you're not sure about your Rust or Gnome libraries knowledge, we recommend you to take a look at the previous parts first.
+In this part we'll go deeper into the mechanisms of the `Gtk-rs` crates. If you're not sure about your Rust or Gnome libraries knowledge, we recommend you to take a look at the previous tutorials first.
 
  * [Specifying version](./version).
  * [Callbacks and closures](./closures).

--- a/docs-src/tutorial/index.md
+++ b/docs-src/tutorial/index.md
@@ -20,3 +20,7 @@ In this part we'll go deeper into the mechanisms of the `Gtk-rs` crates. If you'
  * [Upcast and downcast](./upcast_downcast).
  * [Glade](./glade).
  * [Cross compiling from linux to windows](./cross).
+
+## Going further
+
+Make sure to check the [examples repository](https://github.com/gtk-rs/examples). Also you can take a look at the source code of [projects using `gtk-rs`](/#projects-using-gtk-rs).

--- a/docs-src/tutorial/index.md
+++ b/docs-src/tutorial/index.md
@@ -10,20 +10,20 @@ Here's an introduction to `Gtk-rs` crates. For the users who already know Rust a
 
 This part explains how to add dependencies on the `Gtk-rs` crates, depending on your needs.
 
-[Read it here](/tuto/rust_and_gtk).
+[Read it here](./rust_and_gtk).
 
 ## Gnome libraries and Rust
 
 This part explains a bit how the bindings of the Gnome libraries work in Rust.
 
-[Read it here](/tuto/gnome_and_rust).
+[Read it here](./gnome_and_rust).
 
 ## Full usage of `Gtk-rs` crates
 
 In this part we'll go deeper into the mechanisms of the `Gtk-rs` crates. If you're not sure about your Rust or Gnome libraries knowledge, we recommend you to take a look at the previous parts first.
 
- * [Specifying version](/tuto/version).
- * [Callbacks and closures](/tuto/closures).
- * [Upcast and downcast](/tuto/upcast_downcast).
- * [Glade](/tuto/glade).
- * [Cross compiling from linux to windows](/tuto/cross).
+ * [Specifying version](./version).
+ * [Callbacks and closures](./closures).
+ * [Upcast and downcast](./upcast_downcast).
+ * [Glade](./glade).
+ * [Cross compiling from linux to windows](./cross).

--- a/docs-src/tutorial/rust_and_gtk.md
+++ b/docs-src/tutorial/rust_and_gtk.md
@@ -55,5 +55,5 @@ Now that you know how to import `Gtk-rs` crates into your code, looking at the [
 <div class="footer">
 <div></div>
 <div><a href="/docs-src/tutorial">Going back to summary</a>.</div>
-<div><a href="/tuto/gnome_and_rust">Gnome libraries and Rust</a>.</div>
+<div><a href="./gnome_and_rust">Gnome libraries and Rust</a>.</div>
 </div>

--- a/docs-src/tutorial/rust_and_gtk.md
+++ b/docs-src/tutorial/rust_and_gtk.md
@@ -6,7 +6,7 @@ layout: default
 
 Before going any further, if you don't know Rust at all, we recommend you to read the official [Rust Book](https://doc.rust-lang.org/book/).
 
-Then we recommend you to learn a bit about [Cargo](http://doc.crates.io/index.html).
+Then we recommend you to learn a bit about [Cargo](http://doc.crates.io/index.html) and check the [GTK requirements](/docs-src/requirements).
 
 All done? Perfect!
 

--- a/docs-src/tutorial/upcast_downcast.md
+++ b/docs-src/tutorial/upcast_downcast.md
@@ -54,7 +54,7 @@ assert_eq!(is_a::<_, gtk::Label>(&button), false);
 ```
 
 <div class="footer">
-<div><a href="/tuto/closures">Callbacks and closures</a>.</div>
+<div><a href="./closures">Callbacks and closures</a>.</div>
 <div><a href="/docs-src/tutorial">Going back to summary</a>.</div>
-<div><a href="/tuto/glade">Glade</a>.</div>
+<div><a href="./glade">Glade</a>.</div>
 </div>

--- a/docs-src/tutorial/version.md
+++ b/docs-src/tutorial/version.md
@@ -56,7 +56,7 @@ So when someone has a new enough version of Gtk, it'll be able to build your cra
 ```
 
 <div class="footer">
-<div><a href="/tuto/gnome_and_rust">Gnome libraries and Rust</a>.</div>
+<div><a href="./gnome_and_rust">Gnome libraries and Rust</a>.</div>
 <div><a href="/docs-src/tutorial">Going back to summary</a>.</div>
-<div><a href="/tuto/closures">Callbacks and closures</a>.</div>
+<div><a href="./closures">Callbacks and closures</a>.</div>
 </div>


### PR DESCRIPTION
Here I made the changes I suggested on #97.

Also I'm running Github pages on my fork so you can [see the changes live](https://martinber.github.io/gtk-rs.github.io/). The organization branch is the one I want to merge, the master branch has some extra changes I made to make Github pages work on my domain.

If you have any suggestions I can implement them, otherwise if this is a bad idea you can just close this merge.

Things left to do:

- Below each tutorial there are links to the next tutorial, previous tutorial and the summary, it would be better if the links were not hardcoded inside each `.md` file. Can be solved when [this new merged Jekyll feature is released](https://github.com/jekyll/jekyll/issues/5754), I think that will happen when Jekyll 5.0 releases in about a month.

- I think that the instructions about how to add the dependencies to `Cargo.toml` are on too many places:

    - [Main page: `/index`](https://gtk-rs.org/)

    - [Gtk-rs documentation: `/docs-src/index`](https://gtk-rs.org/docs-src/)

    - [The `rust_and_gtk` tutorial](https://gtk-rs.org/tuto/rust_and_gtk")

    - [The `version` tutorial](https://gtk-rs.org/tuto/version)

Thank you