### PR TITLE
Update the GTK version number in the section Using

### DIFF
--- a/index.md
+++ b/index.md
@@ -43,7 +43,7 @@ Include `gtk` in your `Cargo.toml` and set the minimal GTK version required by y
 ~~~toml
 [dependencies.gtk]
 version = "{{ gtk[0].max_version }}"
-features = ["v3_10"]
+features = ["v3_16"]
 ~~~
 
 __The APIs aren't stable yet. Watch the Announcements box above for breaking changes to the crates!__


### PR DESCRIPTION
Since version 0.6.0, the minimum version of GTK proposed is v3_16.