### PR TITLE
Contact page: Update matrix room & add a link

### DIFF
--- a/docs-src/contact.md
+++ b/docs-src/contact.md
@@ -12,7 +12,9 @@ Channel #rust on **irc.gimp.org** server.
 
 # Matrix
 
-You can connect using: **#gimpnet#gnome:matrix.org**.
+You can connect using: **[#rust:gnome.org][]**.
+
+[#rust:gnome.org]: https://matrix.to/#/#rust:gnome.org
 
 # Github
 


### PR DESCRIPTION
The room id that's currently mentioned on the page doesn't actually exist. `#rust:gnome.org` is the canonical alias for the matrix room bridged to `#rust` on GIMPnet.