### PR TITLE
Change mingw-w64-gtk3 to mingw64-gtk3

### DIFF
--- a/docs-src/tutorial/cross.md
+++ b/docs-src/tutorial/cross.md
@@ -29,7 +29,7 @@ The mingw packages are in the AUR, you can either install manually or use a help
 
 Fedora provides pre-compiled Mingw and GTK packages through its repositories. Both 64 and 32 bits are available (`mingw64-*` vs `mingw32-*`), of which you probably want the 64 bits packages.
 
-    dnf install mingw64-gcc mingw64-pango mingw64-poppler mingw-w64-gtk3
+    dnf install mingw64-gcc mingw64-pango mingw64-poppler mingw64-gtk3
 
 ### Other distributions
 


### PR DESCRIPTION
Changes mingw-w64-gtk3 to mingw64-gtk3 in the list of packages to install on fedora in order to build a .exe