### PR TITLE
Document setup on Windows

### DIFF
--- a/docs-src/index.md
+++ b/docs-src/index.md
@@ -7,6 +7,24 @@ layout: default
 
 First, prepare your system by taking a look at the [GTK installation page](https://www.gtk.org/docs/installations/).
 
+### Setup on Windows
+
+On Windows, some Rust-specific steps are necessary:
+
+1. If you haven't already, [install rustup](https://rustup.rs/)
+2. [Install MSYS2](https://www.msys2.org/)
+3. Open a cmd prompt (not MSYS2 terminal) and run these commands:
+
+       set PATH=C:\msys64\mingw64\bin;%PATH%;C:\msys64\usr\bin
+       set PKG_CONFIG_PATH=C:\msys64\mingw64\lib\pkgconfig
+       set RUSTUP_TOOLCHAIN=stable-x86_64-pc-windows-gnu
+
+       rustup toolchain install stable-x86_64-pc-windows-gnu
+       pacman -S pkg-config mingw-w64-x86_64-gcc mingw-w64-x86_64-gtk3
+
+Now you should able to `cargo run` your Rust project.
+Note that you need to setup the environment variables as above each time you start a new terminal.
+
 ## Crate API docs
 
  - [**atk**](../docs/atk/)


### PR DESCRIPTION
As noted by others (#70, #138), and I also experienced myself, there is currently not enough documentation on using gtk-rs on Windows.

After multiple failed attempts, wondering what I was supposed to do and googling error messages, I found [this thread](https://github.com/gtk-rs/gtk/issues/44), which links to [this file](https://github.com/gtk-rs/examples/blob/master/appveyor.yml). I adapted and simplified these steps a bit, and can confirm that they actually work.

Let's avoid every newcomer wasting a lot of time by adding this to the documentation.

Fixes #70