### PR TITLE
Fallback to monospace for code

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -196,7 +196,7 @@ pre {
 
 code {
     font-weight: bold;
-    font-family: "Roboto Mono";
+    font-family: "Roboto Mono", monospace;
     font-size: 0.9em;
 }
 

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -277,7 +277,7 @@ ul.contact {
                 padding: 15px;
                 margin: 0;
                 line-height: 50px;
-                font-family: Cantarell;
+                font-family: Cantarell, sans-serif;
                 font-weight: bold;
                 font-size: 1.2em;
                 color: $text-color;


### PR DESCRIPTION
Certain configurations of Firefox allow disabling custom web fonts. In
those instances the code samples are using a sans-serif font (if `Roboto
Mono` is not otherwise available).