### PR TITLE
Wrap inside a word if necessary

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -29,6 +29,9 @@ body {
     background-color: $background-color;
     -webkit-text-size-adjust: 100%;
     overflow-x: hidden;
+
+    /* prevent long function namens from breaking the design */
+    word-wrap: break-word;
 }
 
 strong {


### PR DESCRIPTION
Don't let function names like `g_win32_get_package_installation_directory_of_module` break the design