### PR TITLE
2021 gtk-rs release post: cairo doesn't use any traits

### DIFF
--- a/_posts/2021-06-22-new-release.md
+++ b/_posts/2021-06-22-new-release.md
@@ -92,7 +92,7 @@ in the `prelude`, so importing it will give you access to them:
 use gtk::prelude::*;
 
 // ...
-let x = cairo::something();
+let x = pango::something();
 let y = gdk::something();
 ```
 


### PR DESCRIPTION
cairo itself doesn't use prelude and it doesn't make sense to include it in the prelude example