### PR TITLE
Fix section on prelude re-exports

### DIFF
--- a/_posts/2021-06-22-new-release.md
+++ b/_posts/2021-06-22-new-release.md
@@ -85,7 +85,18 @@ to be able to use them. Now, you only need to import GTK and then you can do:
 use gtk::{cairo, gdk};
 ```
 
-The `-sys` crates are also re-exported under the name `ffi`:
+And that's it! It'll make your management of dependencies much simpler. To be noted, they are also
+in the `prelude`, so importing it will give you access to them:
+
+```rust
+use gtk::prelude::*;
+
+// ...
+let x = cairo::something();
+let y = gdk::something();
+```
+
+Last note about the re-exports: the `-sys` crates are also re-exported under the name `ffi`:
 
 ```rust
 use gtk::ffi;

--- a/_posts/2021-06-22-new-release.md
+++ b/_posts/2021-06-22-new-release.md
@@ -85,15 +85,16 @@ to be able to use them. Now, you only need to import GTK and then you can do:
 use gtk::{cairo, gdk};
 ```
 
-And that's it! It'll make your management of dependencies much simpler. To be noted, they are also
-in the `prelude`, so importing it will give you access to them:
+And that's it! It'll make your management of dependencies much simpler. To be noted, relevant traits
+are also re-exported in the `prelude`, so importing it will give you access to them:
 
 ```rust
+use gtk::gdk;
 use gtk::prelude::*;
 
 // ...
-let x = cairo::something();
-let y = gdk::something();
+// This uses the `gdk::prelude::WindowExtManual` trait, through the prelude.
+let w = gdk::Window::default_root_window();
 ```
 
 Last note about the re-exports: the `-sys` crates are also re-exported under the name `ffi`:


### PR DESCRIPTION
This reworks the description of prelude re-exports, in order to clarify
that only blanket traits are re-exported. It also fixes the example
to use a real trait from gdk.

Closes: https://github.com/gtk-rs/gtk-rs.github.io/pull/249