### PR TITLE
Add a libre reimplementation of a Unity3D plugin

### DIFF
--- a/_data/projects.json
+++ b/_data/projects.json
@@ -141,6 +141,10 @@
     "url": "https://github.com/antoyo/relm"
   },
   {
+    "name": "ScreenSelector.so",
+    "url": "https://linkmauve.fr/dev/screen-selector/"
+  },
+  {
     "name": "Shortwave",
     "url": "https://gitlab.gnome.org/World/Shortwave",
     "featured": true,


### PR DESCRIPTION
This plugin lets users configure the resolution, quality and controls before starting the game. The proprietary original uses gtk2 which requires X11 and is unmaintained, this reimplementation uses gtk4 instead.