### PR TITLE
Add pod-ui to projects.json

### DIFF
--- a/_data/projects.json
+++ b/_data/projects.json
@@ -149,6 +149,11 @@
     "url": "https://gitlab.gnome.org/World/podcasts"
   },
   {
+    "name": "pod-ui",
+    "url": "https://github.com/arteme/pod-ui",
+    "description": "A modern UI for controlling Line6 POD family of devices via MIDI."
+  },
+  {
     "name": "Popsicle",
     "url": "https://github.com/pop-os/popsicle/"
   },


### PR DESCRIPTION
Adding pod-ui project to a list of projects using gtk-rs now that pod-ui version 1.0.0 has been released and I feel that the code-base matured to a level...