### PR TITLE
Removed from list the projects that have been archived by their authors

### DIFF
--- a/_data/projects.json
+++ b/_data/projects.json
@@ -26,10 +26,6 @@
     "url": "https://gitlab.gnome.org/World/design/contrast"
   },
   {
-    "name": "Cookbook",
-    "url": "https://github.com/MacKarp/Cookbook"
-  },
-  {
     "name": "Celeste",
     "url": "https://github.com/hwittenborn/celeste",
     "app_id": "com.hunterwittenborn.Celeste",
@@ -88,10 +84,6 @@
     "url": "https://github.com/vhakulinen/gnvim"
   },
   {
-    "name": "gled",
-    "url": "https://gitlab.com/pentagonum/gled"
-  },
-  {
     "name": "glide",
     "url": "https://github.com/philn/glide"
   },
@@ -132,10 +124,6 @@
     "url": "https://codeberg.org/baarkerlounger/jogger",
     "app_id": "xyz.slothlife.Jogger",
     "description": "A Fitness Tracker for Gnome Mobile"
-  },
-  {
-    "name": "Iridium",
-    "url": "https://github.com/matze/iridium"
   },
   {
     "name": "lognplot",
@@ -202,7 +190,7 @@
     "name": "Projectpad",
     "url": "https://github.com/emmanueltouzery/projectpad2"
   },
-  { 
+  {
     "name": "Pt",
     "url": "https://github.com/polachok/pt",
     "description": "Simple terminal"


### PR DESCRIPTION
- [Iridium](https://github.com/matze/iridium)
- [Gled](https://gitlab.com/pentagonum/gled): the link takes you nowhere, but if you remove `/gled` from it (getting `https://gitlab.com/pentagonum`), you find the group's GitLab profile (with a notice that says _Group 'pentagonum' was moved to 'photonenkollektiv'. Please update any links and bookmarks that may still have the old path._). In there, there is a Gled project, but seems to not be using `gtk-rs` any longer. The `Cargo.toml` has no GTK-related dependency. Moreover, it uses `egui`, so it seems they migrated to immediate mode.
- [CookBook](https://github.com/MacKarp/Cookbook)