### PR TITLE
Updated the URL and name of the Telegrand project

### DIFF
--- a/_data/projects.json
+++ b/_data/projects.json
@@ -233,8 +233,8 @@
     "url": "https://gitlab.gnome.org/World/Tau"
   },
   {
-    "name": "Telegrand",
-    "url": "https://github.com/melix99/telegrand"
+    "name": "Paper Plane",
+    "url": "https://github.com/paper-plane-developers/paper-plane"
   },
   {
     "name": "Tundra",


### PR DESCRIPTION
The current URL (`https://github.com/melix99/telegrand`) redirects to `https://github.com/paper-plane-developers/paper-plane`.